### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,9 @@ exports.extract = function (cwd, opts) {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
         var srcpath = path.resolve(cwd, header.linkname)
+        if (!isValidPath(srcpath, cwd)) {
+          return next(new Error('Invalid path: ' + header.linkname))
+        }
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {
@@ -323,6 +326,11 @@ exports.extract = function (cwd, opts) {
   if (opts.finish) extract.on('finish', opts.finish)
 
   return extract
+}
+
+function isValidPath(filePath, root) {
+  const relative = path.relative(root, filePath)
+  return !relative.startsWith('..') && !path.isAbsolute(relative)
 }
 
 function validate (fs, name, root, cb) {


### PR DESCRIPTION
Potential fix for [https://github.com/nine-nines-availability/code-scanning-javascript-demo/security/code-scanning/1](https://github.com/nine-nines-availability/code-scanning-javascript-demo/security/code-scanning/1)

To fix the problem, we need to ensure that the `header.linkname` does not contain any directory traversal elements like `..`. This can be done by validating the path before using it in file system operations. Specifically, we should check that the resolved path is within the intended extraction directory.

1. Add a function to validate the path.
2. Use this function to check `header.linkname` before using it in file system operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
